### PR TITLE
Footer always shown at bottom of window

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,35 +1,50 @@
 <template>
-  <div id="app">
-      <TheNav/>
-      <TheHeader title="Hello"></TheHeader>
-      <Notification></Notification>
+<div id="app">
+  <body class="site">
+    <TheNav />
+    <TheHeader title="Hello"></TheHeader>
+    <Notification></Notification>
+    <main class="site-content">
       <Section></Section>
-      <TheFooter/>
-  </div>
+    </main>
+    <TheFooter />
+  </body>
+</div>
 </template>
 
 <script>
+import TheHeader from "@/components/TheHeader";
+import TheFooter from "@/components/TheFooter";
+import TheNav from "@/components/TheNav";
+import Section from "@/components/Section";
+import Notification from "@/components/Notification";
 
-
-    import TheHeader from "@/components/TheHeader";
-    import TheFooter from "@/components/TheFooter";
-    import TheNav from "@/components/TheNav";
-    import Section from "@/components/Section";
-    import Notification from "@/components/Notification";
-
-    export default {
-        name: "app",
-        components: {Notification, Section, TheNav, TheFooter, TheHeader}
-}
+export default {
+  name: "app",
+  components: { Notification, Section, TheNav, TheFooter, TheHeader }
+};
 </script>
 
 <style>
 #app {
-  font-family: 'Avenir', Helvetica, Arial, sans-serif;
+  font-family: "Avenir", Helvetica, Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   text-align: center;
   color: #2c3e50;
-  margin-top: 55px;
+  margin-top: 0px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+}
+
+.site {
+  display: flex;
+  min-height: 100vh;
+  flex-direction: column;
+}
+
+.site-content {
+  flex: 1;
 }
 </style>

--- a/src/components/TheFooter.vue
+++ b/src/components/TheFooter.vue
@@ -1,17 +1,17 @@
 <template>
-    <footer class="py-5 bg-dark">
-        <div class="container">
-            <p class="m-0 text-center text-white">Copyright &copy; Projecty Web 2019</p>
-        </div>
-    </footer>
+  <footer class="py-5 bg-dark">
+    <p class="m-0 text-center text-white">Copyright &copy; Projecty Web 2019</p>
+  </footer>
 </template>
 
 <script>
-    export default {
-        name: "TheFooter"
-    }
+export default {
+  name: "TheFooter"
+};
 </script>
 
 <style scoped>
-
+footer {
+  bottom: 0;
+}
 </style>


### PR DESCRIPTION
In App.vue if we wrap the header and navbar content in a body tag, and the section in a main tag, we can use flexbox in the styling to always keep the footer at the bottom of the window.
Reference: [https://philipwalton.github.io/solved-by-flexbox/demos/sticky-footer/](url)

**Before:**
![Screenshot 2020-05-17 at 15 31 48](https://user-images.githubusercontent.com/38386086/82151505-ae2b4400-9853-11ea-866c-5561be1297f1.png)

**After**
![Screenshot 2020-05-17 at 15 33 27](https://user-images.githubusercontent.com/38386086/82151540-d5821100-9853-11ea-9957-c6657aca76c0.png)

